### PR TITLE
Filter expired events from the active feed with a grace period (#84)

### DIFF
--- a/backend/src/main/java/bjbites/bjbites_springboot/controller/PostController.java
+++ b/backend/src/main/java/bjbites/bjbites_springboot/controller/PostController.java
@@ -19,11 +19,17 @@ public class PostController {
     
     @Autowired
     private PostRepository postRepository;
-    
-    // Get all active posts
+
+    // How long an event keeps showing in the feed after its availableUntil time
+    // passes, so the frontend can display a countdown before it disappears.
+    private static final long GRACE_PERIOD_MINUTES = 5;
+
+    // Get all active posts (excludes events whose availableUntil passed more than
+    // the grace period ago; events with no end time always show)
     @GetMapping("/active")
     public ResponseEntity<List<Post>> getAllActivePosts() {
-        List<Post> posts = postRepository.findByStatusOrderByCreatedAtDesc("active");
+        LocalDateTime cutoff = LocalDateTime.now().minusMinutes(GRACE_PERIOD_MINUTES);
+        List<Post> posts = postRepository.findActiveWithinGrace("active", cutoff);
         return new ResponseEntity<>(posts, HttpStatus.OK);
     }
 

--- a/backend/src/main/java/bjbites/bjbites_springboot/repository/PostRepository.java
+++ b/backend/src/main/java/bjbites/bjbites_springboot/repository/PostRepository.java
@@ -2,7 +2,11 @@ package bjbites.bjbites_springboot.repository;
 
 import bjbites.bjbites_springboot.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -11,4 +15,14 @@ public interface PostRepository extends JpaRepository<Post, Integer> {
     List<Post> findByOrderByCreatedAtDesc();
     List<Post> findByStatusOrderByCreatedAtDesc(String status);
     List<Post> findByCreatedBy_Id(Integer userId);
+
+    // Active events that have not yet passed the grace cutoff.
+    // Events with no end time (availableUntil is null) are always included.
+    // Events still keep showing for a grace window after their end time so the
+    // frontend can show a countdown rather than removing them instantly.
+    @Query("SELECT p FROM Post p WHERE p.status = :status " +
+           "AND (p.availableUntil IS NULL OR p.availableUntil > :cutoff) " +
+           "ORDER BY p.createdAt DESC")
+    List<Post> findActiveWithinGrace(@Param("status") String status,
+                                     @Param("cutoff") LocalDateTime cutoff);
 }


### PR DESCRIPTION
## Summary:

* The main feed now automatically excludes events whose availableUntil time has passed, so expired events drop off without needing manual closure
* Added a short grace period so an event keeps showing briefly after it ends, which lets the frontend display a countdown rather than removing it instantly (per the team discussion)

## How it works:

* New repository query findActiveWithinGrace returns active events where availableUntil is still in the future, or has passed by less than the grace period
* Events with no end time (availableUntil is null) always show
* The /api/posts/active endpoint passes a cutoff of now minus a 5 minute grace period
* GRACE_PERIOD_MINUTES is a constant so it's easy to adjust

## Files Changed:

* backend/src/main/java/bjbites/bjbites_springboot/repository/PostRepository.java
* backend/src/main/java/bjbites/bjbites_springboot/controller/PostController.java

## Testing:

* Confirmed via curl and on web: a currently active event shows in the feed, while an event whose availableUntil passed beyond the grace period is correctly excluded
* Verified events with a null availableUntil still appear

## Note:

* The countdown display itself is a frontend piece on the feed. This change keeps recently-expired events in the response during the grace window so that countdown can be built later.