### PR TITLE
Fix bundle-breaking syntax error in create-event.tsx

### DIFF
--- a/app/(tabs)/create-event.tsx
+++ b/app/(tabs)/create-event.tsx
@@ -468,6 +468,7 @@ const styles = StyleSheet.create({
     fontWeight: "500",
     marginBottom: 6,
     color: "#555",
+  },
   picker: {
     color: "#000",
   },


### PR DESCRIPTION
The webInputLabel style was missing its closing brace, running it into the picker style and breaking the whole app bundle on main. One-line fix adds the missing }. This unblocks anyone pulling main.