### PR TITLE
Fix post update and delete endpoints

### DIFF
--- a/backend/src/main/java/bjbites/bjbites_springboot/controller/PostController.java
+++ b/backend/src/main/java/bjbites/bjbites_springboot/controller/PostController.java
@@ -153,7 +153,7 @@ public class PostController {
      *      trying to be updated
      */
     @PreAuthorize("hasAuthority('admin') or hasAuthority('event_organizer')")
-    @PutMapping()
+    @PutMapping("/{id}")
     public ResponseEntity<Post> updatePost(@AuthenticationPrincipal OAuth2User oAuthUser, @PathVariable int id, @RequestBody Post postDetails)
     {
         User currentUser = userProvisioningService.getOrCreateUser(oAuthUser);
@@ -203,6 +203,7 @@ public class PostController {
                 post.setAvailableUntil(postDetails.getAvailableUntil());
                 post.setUpdatedAt(LocalDateTime.now());
                 post.setStatus(postDetails.getStatus());
+                return new ResponseEntity<>(postRepository.save(post), HttpStatus.OK);
             }
 
         }
@@ -221,7 +222,7 @@ public class PostController {
      *      trying to be deleted
      */
     @PreAuthorize("hasAuthority('admin') or hasAuthority('event_organizer')")
-    @DeleteMapping()
+    @DeleteMapping("/{id}")
     public ResponseEntity<Void> deletePost(@AuthenticationPrincipal OAuth2User oAuthUser, @PathVariable int id) {
         User currentUser = userProvisioningService.getOrCreateUser(oAuthUser);
 


### PR DESCRIPTION
## Summary:
- Added /{id} to the PUT and DELETE mappings on PostController. They previously mapped to bare /api/posts, so update and close requests returned 405 Method Not Allowed.
- Fixed the admin branch of updatePost, which set all fields but never called save() or returned, causing a 404 and silently dropping the update for admin users.

## Files Changed:
- `backend/src/main/java/bjbites/bjbites_springboot/controller/PostController.java`

## Testing:
- Verified an authenticated admin can edit an event end to end and the change persists.
- Confirmed update returns 200 OK instead of 405/404.