### PR TITLE
Remove prototype sign-up link from sign-in screen

### DIFF
--- a/app/(auth)/sign-in.tsx
+++ b/app/(auth)/sign-in.tsx
@@ -1,4 +1,4 @@
-import { Link, useRouter } from "expo-router";
+import { useRouter } from "expo-router";
 import React, { useState } from "react";
 import {
   ActivityIndicator,
@@ -54,12 +54,6 @@ export default function SignInScreen() {
       )}
 
       {!!error && <Text style={styles.errorText}>{error}</Text>}
-
-      <Link href="/sign-up" asChild>
-        <Pressable style={styles.link}>
-          <Text style={styles.linkText}>View prototype sign-up screen</Text>
-        </Pressable>
-      </Link>
     </View>
   );
 }
@@ -99,13 +93,5 @@ const styles = StyleSheet.create({
     color: "red",
     textAlign: "center",
     marginTop: 16,
-  },
-  link: {
-    marginTop: 20,
-    alignItems: "center",
-  },
-  linkText: {
-    color: "#005CA9",
-    fontSize: 16,
   },
 });


### PR DESCRIPTION
## Summary:
- Removed the "View prototype sign-up screen" link from the sign-in screen, since SSO is now the real authentication path and the prototype sign-up is no longer relevant.
- Removed the now-unused Link import and link styles.

## Files Changed:
- `app/(auth)/sign-in.tsx`

## Testing:
- Sign-in screen renders with only the "Sign in with Creighton" button; no type errors.