### PR TITLE
Admin access: role in session, route guard, and admin events screen (#177, #178, #180)

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -48,6 +48,14 @@ export default function TabsLayout() {
           href: canManageEvents ? undefined : null,
         }}
       />
+      // TODO: Show only for admins after role-based session access is merged.
+      <Tabs.Screen
+        name="admin-events"
+        options={{
+          title: "All Events",
+          tabBarLabel: "Admin",
+        }}
+      />
     </Tabs>
   );
 }

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -48,12 +48,12 @@ export default function TabsLayout() {
           href: canManageEvents ? undefined : null,
         }}
       />
-      // TODO: Show only for admins after role-based session access is merged.
       <Tabs.Screen
         name="admin-events"
         options={{
           title: "All Events",
           tabBarLabel: "Admin",
+          href: isAdmin ? undefined : null,
         }}
       />
     </Tabs>

--- a/app/(tabs)/admin-events.tsx
+++ b/app/(tabs)/admin-events.tsx
@@ -1,0 +1,229 @@
+import React, { useCallback, useState } from "react";
+import { FlatList, Pressable, StyleSheet, Text, View } from "react-native";
+import { router, useFocusEffect } from "expo-router";
+import { Event, fetchAllEvents } from "@/lib/api";
+
+export default function AdminEventsScreen() {
+  const [events, setEvents] = useState<Event[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadAllEvents = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const data = await fetchAllEvents();
+      setEvents(data);
+    } catch (err) {
+      console.error("Error fetching all events:", err);
+      setError("Could not load events.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Reload whenever the tab regains focus so newly created, edited, or closed
+  // events show without needing a remount.
+  useFocusEffect(
+    useCallback(() => {
+      loadAllEvents();
+    }, [loadAllEvents])
+  );
+
+  const activeEvents = events.filter(
+    (event) => event.status === "active"
+  );
+
+  const closedEvents = events.filter(
+    (event) => event.status === "closed"
+  );
+
+  const formatDateTime = (value?: string | null) => {
+    if (!value) return "";
+    try {
+      return new Date(value).toLocaleString();
+    } catch {
+      return value;
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>All Events</Text>
+      <Text style={styles.subtitle}>
+        View active and closed events from all organizers
+      </Text>
+
+      <View style={styles.separator} />
+
+      {loading ? (
+        <View style={styles.stateContainer}>
+          <Text style={styles.statusText}>Loading events...</Text>
+        </View>
+      ) : error ? (
+        <View style={styles.stateContainer}>
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      ) : events.length === 0 ? (
+        <View style={styles.stateContainer}>
+          <Text style={styles.emptyText}>No events found.</Text>
+        </View>
+      ) : (
+        <FlatList
+          data={[
+            {
+                title: "Active Events",
+                events: activeEvents,
+            },
+            {
+                title: "Closed Events",
+                events: closedEvents,
+            },
+          ]}
+          keyExtractor={(section) => section.title}
+          contentContainerStyle={styles.listContent}
+          renderItem={({ item: section }) => (
+            <View style={styles.section}>
+                <Text style={styles.sectionTitle}>
+                    {section.title} ({section.events.length})
+                </Text>
+
+                {section.events.length === 0 ? (
+                    <Text style={styles.emptyText}>
+                        No {section.title.toLowerCase()}.
+                    </Text>
+                ) : (
+                    section.events.map((event) => (
+                        <Pressable
+                            key={event.id}
+                            style={({ pressed }) => [
+                                styles.card,
+                                pressed && styles.cardPressed,
+                            ]}
+                            onPress={() =>
+                                router.push({
+                                    pathname: "/events/[id]",
+                                    params: {
+                                        id: String(event.id),
+                                        from: "admin-events",
+                                    },
+                                })
+                            }
+                        >
+                            <Text style={styles.cardTitle}>{event.title}</Text>
+                            
+                            {!!event.building && (
+                                <Text style={styles.cardLocation}>
+                                    {event.building.buildingName}
+                                    {event.roomNumber ? `, Room ${event.roomNumber}` : ""}
+                                </Text>
+                            )}
+
+                            <Text style={styles.cardStatus}>
+                                Status: {event.status}
+                            </Text>
+
+                            {(event.availableFrom || event.availableUntil) && (
+                                <Text style={styles.cardMeta}>
+                                    {event.availableFrom
+                                        ? `From: ${formatDateTime(event.availableFrom)}`
+                                        : ""}
+                                    {event.availableUntil
+                                        ? ` To: ${formatDateTime(event.availableUntil)}`
+                                        : ""}
+                                </Text>
+                            )}
+                        </Pressable>
+                    ))
+                )}
+            </View>
+          )}
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: "#FFFFFF",
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: "bold",
+    marginBottom: 4,
+    color: "#00235D",
+  },
+  subtitle: {
+    fontSize: 16,
+    color: "#666",
+  },
+  separator: {
+    marginVertical: 16,
+    height: 1,
+    width: "100%",
+    backgroundColor: "#eee",
+  },
+  stateContainer: {
+    paddingVertical: 24,
+    alignItems: "center",
+  },
+  statusText: {
+    fontSize: 14,
+    color: "#666",
+  },
+  emptyText: {
+    fontSize: 14,
+    color: "#888",
+  },
+  errorText: {
+    fontSize: 14,
+    color: "red",
+  },
+  listContent: {
+    paddingVertical: 8,
+  },
+  card: {
+    borderWidth: 1,
+    borderColor: "#005CA9",
+    borderRadius: 8,
+    padding: 12,
+    marginBottom: 10,
+    backgroundColor: "#E9F2FB",
+  },
+  cardPressed: {
+    opacity: 0.9,
+  },
+  cardTitle: {
+    fontSize: 16,
+    fontWeight: "bold",
+    marginBottom: 4,
+    color: "#00235D",
+  },
+  cardLocation: {
+    fontSize: 14,
+    marginBottom: 4,
+  },
+  cardStatus: {
+    fontSize: 13,
+    color: "#444",
+    marginTop: 2,
+  },
+  cardMeta: {
+    marginTop: 4,
+    fontSize: 13,
+    fontStyle: "italic",
+  },
+  section: {
+    marginBottom: 24,
+  },
+  sectionTitle: {
+    fontSize: 20,
+    fontWeight: "600",
+    color: "#00235D",
+    marginBottom: 10,
+  },
+});

--- a/app/(tabs)/admin-events.tsx
+++ b/app/(tabs)/admin-events.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useState } from "react";
 import { FlatList, Pressable, StyleSheet, Text, View } from "react-native";
 import { router, useFocusEffect } from "expo-router";
 import { Event, fetchAllEvents } from "@/lib/api";
+import { AdminRouteGuard } from "@/components/admin-route-guard";
 
 export default function AdminEventsScreen() {
   const [events, setEvents] = useState<Event[]>([]);
@@ -49,6 +50,7 @@ export default function AdminEventsScreen() {
   };
 
   return (
+    <AdminRouteGuard>
     <View style={styles.container}>
       <Text style={styles.title}>All Events</Text>
       <Text style={styles.subtitle}>
@@ -142,6 +144,7 @@ export default function AdminEventsScreen() {
         />
       )}
     </View>
+    </AdminRouteGuard>
   );
 }
 

--- a/app/contexts/session-context.tsx
+++ b/app/contexts/session-context.tsx
@@ -54,6 +54,17 @@ const prototypeUsers: Record<number, User> = {
             description: "Can create and manage their own food events",
         },
     },
+    4: {
+        id: 4,
+        email: "testadmin@example.com",
+        displayName: "Test Admin",
+        authProvider: "local",
+        role: {
+            id: 3,
+            roleName: "admin",
+            description: "Full platform oversight and management",
+        },
+    },
 };
 
 const SessionContext = createContext<SessionContextValue | undefined>(

--- a/app/events/[id]/edit.tsx
+++ b/app/events/[id]/edit.tsx
@@ -13,7 +13,7 @@ import {
 } from "react-native";
 import { Picker } from "@react-native-picker/picker";
 import DateTimePicker from "@react-native-community/datetimepicker";
-import { Stack, router, useLocalSearchParams } from "expo-router";
+import { Stack, router, useLocalSearchParams, Redirect } from "expo-router";
 import {
     Building,
     Event,
@@ -43,6 +43,7 @@ export default function EditEventScreen() {
     const [loadingDietaryOptions, setLoadingDietaryOptions] = useState(false);
     const [loadingEvent, setLoadingEvent] = useState(true);
     const [loadError, setLoadError] = useState<string | null>(null);
+    const [accessDenied, setAccessDenied] = useState(false);
 
     const [servingsMin, setServingsMin] = useState<number | null>(null);
     const [servingsMax, setServingsMax] = useState<number | null>(null);
@@ -125,12 +126,8 @@ export default function EditEventScreen() {
                 const canEdit = isAdmin || (isOrganizer && isCreator);
 
                 if (!canEdit) {
-                    Alert.alert("Not allowed", "Only the event creator can edit this event.", [
-                        {
-                            text: "OK",
-                            onPress: () => router.back(),
-                        },
-                    ]);
+                    setAccessDenied(true);
+                    setLoadingEvent(false);
                     return;
                 }
 
@@ -308,6 +305,10 @@ export default function EditEventScreen() {
             setSubmitting(false);
         }
     };
+
+    if (accessDenied) {
+        return <Redirect href="/" />;
+    }
 
     if (loadingEvent) {
         return (

--- a/components/admin-route-guard.tsx
+++ b/components/admin-route-guard.tsx
@@ -1,0 +1,21 @@
+import React, { type ReactNode } from "react";
+import { useSession } from "@/app/contexts/session-context";
+import { Redirect } from "expo-router";
+
+type AdminRouteGuardProps = {
+    children: ReactNode;
+};
+
+export function AdminRouteGuard({
+    children,
+}: AdminRouteGuardProps) {
+    const { isAdmin } = useSession();
+
+    // Admin-only: unlike the organizer guard, this does NOT allow organizers.
+    // Only users with the admin role may access the wrapped screen.
+    if (!isAdmin) {
+        return <Redirect href="/" />;
+    }
+
+    return <>{children}</>;
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -258,3 +258,15 @@ export async function uploadPhoto(file: { uri: string; name: string; type: strin
   }
   return res.json();
 }
+
+export async function fetchAllEvents(): Promise<Event[]> {
+  const res = await fetch(`${POSTS_URL}/all`);
+
+  if (!res.ok) {
+    const text = await res.text();
+    console.error("Failed to fetch all events", res.status, text);
+    throw new Error(text || "Failed to fetch all events");
+  }
+
+  return res.json();
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -296,7 +296,7 @@ export async function uploadPhoto(file: { uri: string; name: string; type: strin
 }
 
 export async function fetchAllEvents(): Promise<Event[]> {
-  const res = await fetch(`${POSTS_URL}/all`);
+  const res = await fetch(`${POSTS_URL}/all`, { credentials: "include" });
 
   if (!res.ok) {
     const text = await res.text();


### PR DESCRIPTION
## Summary:
- Added the admin role to the prototype session so isAdmin resolves (#177).
- Added AdminRouteGuard, which restricts a screen to admins only (not organizers), and wrapped the admin events screen in it (#178).
- Hid the Admin tab from non-admins in the tabs layout (href gated on isAdmin).
- Verified the full role matrix (#180): regular users and organizers see no Admin tab and are redirected away from /admin-events; admins see the tab and the screen loads.

## Files Changed:
- `app/contexts/session-context.tsx`
- `components/admin-route-guard.tsx`
- `app/(tabs)/_layout.tsx`
- `app/(tabs)/admin-events.tsx` (merged from Erika's admin-all-events-page branch)
- `app/events/[id]/edit.tsx` (unauthorized users redirected instead of shown a blank form)
- `lib/api.ts` (fetchAllEvents, from the merge)

## Testing:
- User 2 (regular): no Admin tab; direct nav to /admin-events redirects to dashboard.
- User 1 (organizer): no Admin tab; direct nav redirects (guard is admin-only, not organizer-or-admin).
- User 4 (admin): Admin tab visible; screen loads showing all events.