### PR TITLE
Fix ordering of URL so that web pulls from localhost URL first

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -115,10 +115,10 @@ export type UpdateEvent = {
 const BACKEND_PORT = 8080;
 
 function resolveBaseUrl(): string {
+  if (Platform.OS === "web") return `http://localhost:${BACKEND_PORT}`;
+
   const configured = process.env.EXPO_PUBLIC_API_URL;
   if (configured) return configured;
-
-  if (Platform.OS === "web") return `http://localhost:${BACKEND_PORT}`;
 
   // hostUri looks like "192.168.86.154:8081" when served to a device.
   const hostUri =


### PR DESCRIPTION
## Summary:
- Changed the ordering of the URL that resolveBaseUrl() pulls from
- Ensures that web runs on localhost before trying to look for an IP address in an env variable

## Files Changed:
- `lib/api.ts`

## Testing:
- Confirmed that reordering and keeping env variable unblocked incorrect redirect URI issue and allowed successful PUT request on web involving an OAuth user with an active session