### PR TITLE
Automatically close expired events (#255)

### DIFF
--- a/backend/src/main/java/bjbites/bjbites_springboot/BJBitesSpringbootApplication.java
+++ b/backend/src/main/java/bjbites/bjbites_springboot/BJBitesSpringbootApplication.java
@@ -2,10 +2,12 @@ package bjbites.bjbites_springboot;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import de.codecentric.boot.admin.server.config.EnableAdminServer;
 
 @SpringBootApplication
+@EnableScheduling
 @EnableAdminServer
 public class BJBitesSpringbootApplication {
 

--- a/backend/src/main/java/bjbites/bjbites_springboot/config/EventConstants.java
+++ b/backend/src/main/java/bjbites/bjbites_springboot/config/EventConstants.java
@@ -1,0 +1,18 @@
+package bjbites.bjbites_springboot.config;
+
+/**
+ * Shared constants for event lifecycle behavior.
+ */
+public final class EventConstants {
+
+    private EventConstants() {
+    }
+
+    /**
+     * How long an event keeps showing in the active feed after its
+     * availableUntil time passes, so the frontend can show a countdown
+     * before it disappears. Both the active-events query and the scheduled
+     * close job use this so the two stay consistent.
+     */
+    public static final long GRACE_PERIOD_MINUTES = 5;
+}

--- a/backend/src/main/java/bjbites/bjbites_springboot/controller/PostController.java
+++ b/backend/src/main/java/bjbites/bjbites_springboot/controller/PostController.java
@@ -1,6 +1,7 @@
 package bjbites.bjbites_springboot.controller;
 
 import bjbites.bjbites_springboot.entity.Post;
+import bjbites.bjbites_springboot.config.EventConstants;
 import bjbites.bjbites_springboot.repository.PostRepository;
 import bjbites.bjbites_springboot.repository.UserRepository;
 import bjbites.bjbites_springboot.service.NotificationService;
@@ -35,9 +36,6 @@ public class PostController {
     @Autowired
     private bjbites.bjbites_springboot.service.UserProvisioningService userProvisioningService;
 
-    // How long an event keeps showing in the feed after its availableUntil time
-    // passes, so the frontend can display a countdown before it disappears.
-    private static final long GRACE_PERIOD_MINUTES = 5;
 
     // Get all active posts (excludes events whose availableUntil passed more than
     // the grace period ago; events with no end time always show)
@@ -47,7 +45,7 @@ public class PostController {
      */
     @GetMapping("/active")
     public ResponseEntity<List<Post>> getAllActivePosts() {
-        LocalDateTime cutoff = LocalDateTime.now().minusMinutes(GRACE_PERIOD_MINUTES);
+        LocalDateTime cutoff = LocalDateTime.now().minusMinutes(EventConstants.GRACE_PERIOD_MINUTES);
         List<Post> posts = postRepository.findActiveWithinGrace("active", cutoff);
         return new ResponseEntity<>(posts, HttpStatus.OK);
     }

--- a/backend/src/main/java/bjbites/bjbites_springboot/repository/PostRepository.java
+++ b/backend/src/main/java/bjbites/bjbites_springboot/repository/PostRepository.java
@@ -27,7 +27,7 @@ public interface PostRepository extends JpaRepository<Post, Integer> {
 
     // Events still marked active whose end time has passed. Used to close them out.
     @Query("SELECT p FROM Post p WHERE p.status = :status " +
-           "AND p.availableUntil IS NOT NULL AND p.availableUntil < :now")
+           "AND p.availableUntil IS NOT NULL AND p.availableUntil < :cutoff")
     List<Post> findExpiredActive(@Param("status") String status,
-                                 @Param("now") LocalDateTime now);
+                                 @Param("cutoff") LocalDateTime cutoff);
 }

--- a/backend/src/main/java/bjbites/bjbites_springboot/repository/PostRepository.java
+++ b/backend/src/main/java/bjbites/bjbites_springboot/repository/PostRepository.java
@@ -24,4 +24,10 @@ public interface PostRepository extends JpaRepository<Post, Integer> {
            "ORDER BY p.createdAt DESC")
     List<Post> findActiveWithinGrace(@Param("status") String status,
                                      @Param("cutoff") LocalDateTime cutoff);
+
+    // Events still marked active whose end time has passed. Used to close them out.
+    @Query("SELECT p FROM Post p WHERE p.status = :status " +
+           "AND p.availableUntil IS NOT NULL AND p.availableUntil < :now")
+    List<Post> findExpiredActive(@Param("status") String status,
+                                 @Param("now") LocalDateTime now);
 }

--- a/backend/src/main/java/bjbites/bjbites_springboot/service/EventStatusService.java
+++ b/backend/src/main/java/bjbites/bjbites_springboot/service/EventStatusService.java
@@ -2,6 +2,7 @@ package bjbites.bjbites_springboot.service;
 
 import bjbites.bjbites_springboot.entity.Post;
 import bjbites.bjbites_springboot.repository.PostRepository;
+import bjbites.bjbites_springboot.config.EventConstants;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
@@ -26,7 +27,10 @@ public class EventStatusService {
     @Scheduled(fixedRate = 600000)
     public void closeExpiredEvents() {
         LocalDateTime now = LocalDateTime.now();
-        List<Post> expired = postRepository.findExpiredActive("active", now);
+        // Wait out the same grace period the active feed uses before closing,
+        // so an event isn't pulled from the feed before its countdown ends.
+        LocalDateTime cutoff = now.minusMinutes(EventConstants.GRACE_PERIOD_MINUTES);
+        List<Post> expired = postRepository.findExpiredActive("active", cutoff);
         for (Post post : expired) {
             post.setStatus("closed");
             post.setUpdatedAt(now);

--- a/backend/src/main/java/bjbites/bjbites_springboot/service/EventStatusService.java
+++ b/backend/src/main/java/bjbites/bjbites_springboot/service/EventStatusService.java
@@ -1,0 +1,38 @@
+package bjbites.bjbites_springboot.service;
+
+import bjbites.bjbites_springboot.entity.Post;
+import bjbites.bjbites_springboot.repository.PostRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * Periodically closes events whose availableUntil time has passed but whose
+ * status is still "active", so the stored status reflects reality and expired
+ * events show up under closed events rather than falling into a gap.
+ */
+@Service
+public class EventStatusService {
+
+    private final PostRepository postRepository;
+
+    public EventStatusService(PostRepository postRepository) {
+        this.postRepository = postRepository;
+    }
+
+    // Runs every 10 minutes. fixedRate is in milliseconds.
+    @Scheduled(fixedRate = 600000)
+    public void closeExpiredEvents() {
+        LocalDateTime now = LocalDateTime.now();
+        List<Post> expired = postRepository.findExpiredActive("active", now);
+        for (Post post : expired) {
+            post.setStatus("closed");
+            post.setUpdatedAt(now);
+        }
+        if (!expired.isEmpty()) {
+            postRepository.saveAll(expired);
+        }
+    }
+}


### PR DESCRIPTION
## Summary:
- Added a scheduled job (EventStatusService) that runs every 10 minutes and sets status to "closed" for events whose availableUntil has passed but were still marked active. Previously status only changed on manual deletion, so time-expired events fell into a gap: filtered out of /active past the grace window, but never appearing under /closed.
- Added findExpiredActive to PostRepository to find active events past their end time.
- Enabled scheduling with @EnableScheduling.

## Files Changed:
- backend/.../service/EventStatusService.java (new)
- backend/.../repository/PostRepository.java
- backend/.../BJBitesSpringbootApplication.java

## Testing:
- Set an event to active with availableUntil in the past, started the backend, and confirmed the scheduled job flipped its status to closed. Verified it then appears under Closed on the admin All Events screen.