### PR TITLE
Allow events to be created by getting authenticated user

### DIFF
--- a/backend/src/main/java/bjbites/bjbites_springboot/controller/PostController.java
+++ b/backend/src/main/java/bjbites/bjbites_springboot/controller/PostController.java
@@ -117,11 +117,10 @@ public class PostController {
      */
     @PreAuthorize("hasAuthority('admin') or hasAuthority('event_organizer')")
     @PostMapping("/create")
-    public ResponseEntity<Post> createPost(@RequestBody Post post) {
+    public ResponseEntity<Post> createPost(@AuthenticationPrincipal OAuth2User oAuthUser, @RequestBody Post post) {
         try {
 
-            User creator = userRepository.findById(post.getCreatedBy().getId())
-                    .orElseThrow(() -> new RuntimeException("User not found"));
+            User creator = userProvisioningService.getOrCreateUser(oAuthUser);
 
             post.setCreatedBy(creator);
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -199,6 +199,7 @@ export async function createEvent(event: NewEvent): Promise<Event> {
   const res = await fetch(`${POSTS_URL}/create`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    credentials: "include",
     body: JSON.stringify(event),
   });
   if (!res.ok) {


### PR DESCRIPTION
## Summary:
- Added @AuthenticatedPrincipal to PostController in order to get the currently authenticated user when creating an event
- Updated create event fetch endpoint to include authenticated user credentials

## Files Changed:
- `backend/src/main/java/bjbites/bjbites_springboot/controller/PostController.java`
- `lib/api.ts`

## Testing:
- Confirmed that events can now be created without a 500 error
- When trying to create an event with a photo, there is currently a CORS error with status code 302