### PR TITLE
Fix default event times and photo upload handling

### DIFF
--- a/app/(tabs)/create-event.tsx
+++ b/app/(tabs)/create-event.tsx
@@ -29,6 +29,19 @@ import { Picker } from "@react-native-picker/picker";
 import { useSession } from "@/app/contexts/session-context";
 import { OrganizerRouteGuard } from "@/components/organizer-route-guard";
 
+function createDefaultAvailability() {
+  const from = new Date();
+
+  // Start five minutes in the future so it does not become stale while the user completes the form.
+  from.setMinutes(from.getMinutes() + 5);
+  from.setSeconds(0, 0);
+
+  const until = new Date(from);
+  until.setHours(until.getHours() + 1);
+
+  return { from, until };
+}
+
 export default function CreateEventScreen() {
   const [title, setTitle] = useState("");
   const [description, setDescription] = useState("");
@@ -45,8 +58,9 @@ export default function CreateEventScreen() {
   const [loadingDietaryOptions, setLoadingDietaryOptions] = useState(false);
   const [servingsMin, setServingsMin] = useState<number | null>(null);
   const [servingsMax, setServingsMax] = useState<number | null>(null);
-  const [availableFrom, setAvailableFrom] = useState<Date | null>(null);
-  const [availableUntil, setAvailableUntil] = useState<Date | null>(null);
+  const [initialAvailability] = useState(() => createDefaultAvailability());
+  const [availableFrom, setAvailableFrom] = useState<Date | null>(initialAvailability.from);
+  const [availableUntil, setAvailableUntil] = useState<Date | null>(initialAvailability.until);
   const [showFromPicker, setShowFromPicker] = useState(false);
   const [showUntilPicker, setShowUntilPicker] = useState(false);
   const [photoUrl, setPhotoUrl] = useState<string | null>(null);
@@ -282,6 +296,7 @@ export default function CreateEventScreen() {
 
     try {
       const createdEvent = await createEvent(payload);
+      const nextAvailability = createDefaultAvailability();
 
       if (photoUrl) {
         const filename = photoUrl.split("/").pop() ?? "photo.jpg";
@@ -303,8 +318,8 @@ export default function CreateEventScreen() {
       setSelectedDietaryOptionIds([]);
       setServingsMin(null);
       setServingsMax(null);
-      setAvailableFrom(null);
-      setAvailableUntil(null);
+      setAvailableFrom(nextAvailability.from);
+      setAvailableUntil(nextAvailability.until);
       setPhotoUrl(null);
     } catch (err: any) {
       console.error("Error creating event:", err);
@@ -609,7 +624,7 @@ export default function CreateEventScreen() {
 
       {Platform.OS !== "web" && showFromPicker && (
         <DateTimePicker
-          value={availableFrom ?? new Date()}
+          value={availableFrom ?? initialAvailability.from}
           mode="datetime"
           display={Platform.OS === "ios" ? "inline" : "default"}
           onChange={(event, selectedDate) => {
@@ -625,7 +640,7 @@ export default function CreateEventScreen() {
 
       {Platform.OS !== "web" && showUntilPicker && (
         <DateTimePicker 
-          value={availableUntil ?? availableFrom ?? new Date()}
+          value={availableUntil ?? availableFrom ?? initialAvailability.until}
           mode="datetime"
           display={Platform.OS === "ios" ? "inline" : "default"}
           onChange={(event, selectedDate) => {

--- a/app/(tabs)/create-event.tsx
+++ b/app/(tabs)/create-event.tsx
@@ -298,17 +298,21 @@ export default function CreateEventScreen() {
       const createdEvent = await createEvent(payload);
       const nextAvailability = createDefaultAvailability();
 
-      if (photoUrl) {
-        const filename = photoUrl.split("/").pop() ?? "photo.jpg";
-        const match = /\.(\w+)$/.exec(filename);
-        const type = match ? `image/${match[1]}` : "image/jpeg";
+      let photoUploadFailed = false;
 
-        await uploadPhoto({ uri: photoUrl, name: filename, type }, createdEvent.id);
+      if (photoUrl) {
+        try {
+          const filename = photoUrl.split("/").pop() ?? "photo.jpg";
+          const match = /\.(\w+)$/.exec(filename);
+          const type = match ? `image/${match[1]}` : "image/jpeg";
+
+          await uploadPhoto({ uri: photoUrl, name: filename, type }, createdEvent.id);
+        } catch (photoError) {
+          photoUploadFailed = true;
+          console.error("Event created, but photo upload failed:", photoError);
+        }
       }
 
-
-      Alert.alert("Success", "Food event created successfully!");
-      
       setTitle("");
       setDescription("");
       setDirections("");
@@ -321,6 +325,19 @@ export default function CreateEventScreen() {
       setAvailableFrom(nextAvailability.from);
       setAvailableUntil(nextAvailability.until);
       setPhotoUrl(null);
+
+      const message = photoUploadFailed
+        ? "The event was created, but the photo could not be uploaded."
+        : "Food event created successfully!";
+
+      if (Platform.OS === "web") {
+        window.alert(message);
+      } else {
+        Alert.alert(
+          photoUploadFailed ? "Event created" : "Success",
+          message
+        );
+      }
     } catch (err: any) {
       console.error("Error creating event:", err);
       Alert.alert(


### PR DESCRIPTION
## Summary
- Fix the default start and end times on the create event form
- Allow the form to clear even when the event photo fails to upload
- Show a message when the event is created but the photo upload fails

## Files Changed:
- `app/(tabs)/create-event.tsx`

## Testing
- Confirmed the form opens with valid default times
- Confirmed an event can be created without changing the default times
- Confirmed the form clears after submission
- Confirmed a photo upload failure does not prevent the event from being created

Closes #249