### PR TITLE
Add admin close-event action with confirmation (#192, #193)

### DIFF
--- a/app/(tabs)/admin-events.tsx
+++ b/app/(tabs)/admin-events.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react";
-import { Alert, FlatList, Pressable, StyleSheet, Text, View } from "react-native";
+import { Alert, FlatList, Platform, Pressable, StyleSheet, Text, View } from "react-native";
 import { router, useFocusEffect } from "expo-router";
 import { Event, fetchAllEvents, closeEvent } from "@/lib/api";
 import { AdminRouteGuard } from "@/components/admin-route-guard";
@@ -24,7 +24,7 @@ export default function AdminEventsScreen() {
     }
   }, []);
 
-  const handleClose = useCallback(
+  const performClose = useCallback(
     async (eventId: number) => {
       try {
         await closeEvent(eventId);
@@ -35,6 +35,27 @@ export default function AdminEventsScreen() {
       }
     },
     [loadAllEvents]
+  );
+
+  const handleClose = useCallback(
+    (eventId: number, eventTitle: string) => {
+      const message = `Close "${eventTitle}"? This will move it to closed for everyone.`;
+      if (Platform.OS === "web") {
+        if (window.confirm(message)) {
+          performClose(eventId);
+        }
+        return;
+      }
+      Alert.alert("Close event?", message, [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Close",
+          style: "destructive",
+          onPress: () => performClose(eventId),
+        },
+      ]);
+    },
+    [performClose]
   );
 
   // Reload whenever the tab regains focus so newly created, edited, or closed
@@ -155,7 +176,7 @@ export default function AdminEventsScreen() {
                                         styles.closeButton,
                                         pressed && styles.closeButtonPressed,
                                     ]}
-                                    onPress={() => handleClose(event.id)}
+                                    onPress={() => handleClose(event.id, event.title)}
                                 >
                                     <Text style={styles.closeButtonText}>Close event</Text>
                                 </Pressable>

--- a/app/(tabs)/admin-events.tsx
+++ b/app/(tabs)/admin-events.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useState } from "react";
-import { FlatList, Pressable, StyleSheet, Text, View } from "react-native";
+import { Alert, FlatList, Pressable, StyleSheet, Text, View } from "react-native";
 import { router, useFocusEffect } from "expo-router";
-import { Event, fetchAllEvents } from "@/lib/api";
+import { Event, fetchAllEvents, closeEvent } from "@/lib/api";
 import { AdminRouteGuard } from "@/components/admin-route-guard";
 
 export default function AdminEventsScreen() {
@@ -23,6 +23,19 @@ export default function AdminEventsScreen() {
       setLoading(false);
     }
   }, []);
+
+  const handleClose = useCallback(
+    async (eventId: number) => {
+      try {
+        await closeEvent(eventId);
+        await loadAllEvents();
+      } catch (err) {
+        console.error("Error closing event:", err);
+        Alert.alert("Error", "Could not close the event. Please try again.");
+      }
+    },
+    [loadAllEvents]
+  );
 
   // Reload whenever the tab regains focus so newly created, edited, or closed
   // events show without needing a remount.
@@ -136,6 +149,17 @@ export default function AdminEventsScreen() {
                                         : ""}
                                 </Text>
                             )}
+                            {event.status === "active" && (
+                                <Pressable
+                                    style={({ pressed }) => [
+                                        styles.closeButton,
+                                        pressed && styles.closeButtonPressed,
+                                    ]}
+                                    onPress={() => handleClose(event.id)}
+                                >
+                                    <Text style={styles.closeButtonText}>Close event</Text>
+                                </Pressable>
+                            )}
                         </Pressable>
                     ))
                 )}
@@ -219,6 +243,22 @@ const styles = StyleSheet.create({
     marginTop: 4,
     fontSize: 13,
     fontStyle: "italic",
+  },
+  closeButton: {
+    marginTop: 10,
+    backgroundColor: "#B00020",
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 6,
+    alignSelf: "flex-start",
+  },
+  closeButtonPressed: {
+    opacity: 0.85,
+  },
+  closeButtonText: {
+    color: "#fff",
+    fontSize: 14,
+    fontWeight: "600",
   },
   section: {
     marginBottom: 24,


### PR DESCRIPTION
## Summary
- Added a "Close event" button to active event cards on the admin All Events screen (#192). It calls the closeEvent endpoint and refreshes the list so the event moves to Closed. Button only shows on active events.
- Added a confirmation step before closing (#193): tapping Close now prompts "Close [event]?" and only closes on confirm. Uses window.confirm on web and Alert.alert on native.

## Testing
- Closed an active event as admin — confirmed it moves to Closed.
- Confirmation prompt appears; Cancel leaves the event active, Confirm closes it. Verified both paths.